### PR TITLE
🔧NoteList保存ロジックの復元・端末のテーマ変更に伴ったダークモード表示の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![4cdf1c5482cd30174cfe](https://user-images.githubusercontent.com/111550856/210683481-2884eac0-efa4-4bcd-9e04-457688744441.png)
+
 # engineer-study-app
 これは、私がflutterで初めて作ったアプリです。MarkDown形式でのメモ、GitHubリポジトリの検索機能を実装予定です。
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@
 | ---- | ---- | ---- | ---- |
 |![Screenshot_20230105-103835](https://user-images.githubusercontent.com/111550856/210685160-a30de5f6-51cc-42cd-b9f6-9f190f66f531.png) | ![Screenshot_20230105-103855](https://user-images.githubusercontent.com/111550856/210685173-25a90d20-f44a-452c-8d53-74bf69632dbe.png)|![Screenshot_20230105-103931](https://user-images.githubusercontent.com/111550856/210685380-b355e445-c78d-4fc6-bf24-475c4185293a.png)|![Screenshot_20230105-103923](https://user-images.githubusercontent.com/111550856/210685464-e79abe72-4c37-495b-a966-fc7bab91176e.png)|
 
+後でgif画像を添付し直す
+メモ新規作成
+https://user-images.githubusercontent.com/111550856/210686424-ab32eada-2cb3-41af-b534-2c510cc5d144.mp4
+
+メモ編集
+https://user-images.githubusercontent.com/111550856/210686473-90194df3-a910-43b5-9db4-c53f712112ad.mp4
+
+メモ削除
+https://user-images.githubusercontent.com/111550856/210686520-705ed1f0-281b-427c-a34f-8ecec385ad2f.mp4
+
+
 
 ## フォルダ構成
 <pre>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 ![4cdf1c5482cd30174cfe](https://user-images.githubusercontent.com/111550856/210683481-2884eac0-efa4-4bcd-9e04-457688744441.png)
 
 # engineer-study-app
-これは、私がflutterで初めて作ったアプリです。MarkDown形式でのメモ、GitHubリポジトリの検索機能を実装予定です。
+[flutter_markdown](https://pub.dev/packages/flutter_markdown)を利用してメモ・ノートをmarkdown形式で表示、保存するメモアプリです。
+
+本アプリを通して「今後のエンジニア人生におけるリファレンスコードとする」、「新しい技術を使ってみる練習場とする」ことを目的としています。
+
+|  メモ一覧（Light）  |  メモ一覧（Dark）  |
+| ---- | ---- |
+|   ![Screenshot_20230105-102918](https://user-images.githubusercontent.com/111550856/210684671-92d66aa2-574f-4e4a-b0e5-cefa5e8003fa.png)|  ![Screenshot_20230105-102851](https://user-images.githubusercontent.com/111550856/210684692-beb80e9f-fe26-4343-95e1-9ee9d41c9aad.png)  |
+
+|  メモ表示（Light）  |  メモ編集（Light）  |  メモ表示（Dark）  |  メモ編集（Dark）  |
+| ---- | ---- | ---- | ---- |
+|![Screenshot_20230105-103835](https://user-images.githubusercontent.com/111550856/210685160-a30de5f6-51cc-42cd-b9f6-9f190f66f531.png) | ![Screenshot_20230105-103855](https://user-images.githubusercontent.com/111550856/210685173-25a90d20-f44a-452c-8d53-74bf69632dbe.png)|![Screenshot_20230105-103931](https://user-images.githubusercontent.com/111550856/210685380-b355e445-c78d-4fc6-bf24-475c4185293a.png)|![Screenshot_20230105-103923](https://user-images.githubusercontent.com/111550856/210685464-e79abe72-4c37-495b-a966-fc7bab91176e.png)|
+
 
 ## フォルダ構成
 <pre>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 |![Screenshot_20230105-103835](https://user-images.githubusercontent.com/111550856/210685160-a30de5f6-51cc-42cd-b9f6-9f190f66f531.png) | ![Screenshot_20230105-103855](https://user-images.githubusercontent.com/111550856/210685173-25a90d20-f44a-452c-8d53-74bf69632dbe.png)|![Screenshot_20230105-103931](https://user-images.githubusercontent.com/111550856/210685380-b355e445-c78d-4fc6-bf24-475c4185293a.png)|![Screenshot_20230105-103923](https://user-images.githubusercontent.com/111550856/210685464-e79abe72-4c37-495b-a966-fc7bab91176e.png)|
 
 後でgif画像を添付し直す
+
 メモ新規作成
 https://user-images.githubusercontent.com/111550856/210686424-ab32eada-2cb3-41af-b534-2c510cc5d144.mp4
 

--- a/lib/view/note/note_view.dart
+++ b/lib/view/note/note_view.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: invalid_use_of_protected_member
+// ignore_for_file: invalid_use_of_protected_member, unused_local_variable
 
 import 'package:engineer_study_app/model/db/note_db.dart';
 import 'package:engineer_study_app/view/note/editor/editor.dart';
@@ -11,13 +11,14 @@ class NoteList extends HookConsumerWidget {
   const NoteList({Key? key}) : super(key: key);
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    // 現在のDBの状態を保持、提供
+    final noteState = ref.watch(noteDatabaseProvider);
     // TempNoteItemDataの状態取得、編集を可能にする
     final editNoteProvider = ref.watch(editingNoteProvider.notifier);
     // Providerのメソッドや値を取得。
     final noteProvider = ref.watch(noteDatabaseProvider.notifier);
     // Providerが保持しているnoteItemsを取得。
     List<NoteItemData> noteItems = noteProvider.state.noteItems;
-    
 
     return Scaffold(
       body: ListView(children: [
@@ -60,8 +61,8 @@ class NoteList extends HookConsumerWidget {
                     noteItems[i].isNotify);
                 // temp = temp.copyWith(id: noteItems[i].id);
                 ref.read(currentNoteIndexProvider.notifier).state = i;
-                await Navigator.push(
-                    context, MaterialPageRoute(builder: (context) => const Editor()));
+                await Navigator.push(context,
+                    MaterialPageRoute(builder: (context) => const Editor()));
               },
             ),
           ),


### PR DESCRIPTION
## 🔧 NoteList保存ロジックの復元
- note_view.dart
  - リファクタリング時にnoteStateを削除してしまっていたことによるNoteList描画の不具合解消
   - 別画面に遷移しないと再描画されないようになっていた 
 
## 🔧 端末のテーマ変更に伴ったダークモード表示の実装
- main.dart
  - darkTheme: ThemeData.dark(),を追加し、端末設定に依存したダークテーマ表示を実装

##📱 動作確認
- 実機での動作確認
  - Android12 Pixel3

## ✏️  README.mdの編集
- 説明、アプリ画像、動画の添付

close #2 